### PR TITLE
passing opts variable to multiple app.hsi functions

### DIFF
--- a/context.js
+++ b/context.js
@@ -63,7 +63,7 @@ context.prototype.rmdir = function(path, opts, cb) {
     }
     var prev_env = app.hpss.env;
     app.hpss.env = this.env;
-    app.hsi.rmdir(path, function(err, out) {
+    app.hsi.rmdir(path, opts, function(err, out) {
         app.hpss.env = prev_env; //restore
         cb(err, out);
     });
@@ -76,7 +76,7 @@ context.prototype.rm = function(path, opts, cb) {
     }
     var prev_env = app.hpss.env;
     app.hpss.env = this.env;
-    app.hsi.rm(path, function(err, out) {
+    app.hsi.rm(path, opts, function(err, out) {
         app.hpss.env = prev_env; //restore
         cb(err, out);
     });
@@ -89,7 +89,7 @@ context.prototype.touch = function(path, opts, cb) {
     }
     var prev_env = app.hpss.env;
     app.hpss.env = this.env;
-    app.hsi.touch(path, function(err, out) {
+    app.hsi.touch(path, opts, function(err, out) {
         app.hpss.env = prev_env; //restore
         cb(err, out);
     });
@@ -102,7 +102,7 @@ context.prototype.mkdir = function(path, opts, cb) {
     }
     var prev_env = app.hpss.env;
     app.hpss.env = this.env;
-    app.hsi.mkdir(path, function(err, out) {
+    app.hsi.mkdir(path, opts, function(err, out) {
         app.hpss.env = prev_env; //restore
         cb(err, out);
     });


### PR DESCRIPTION
I noticed that the sca-service-hpss was executing 'mkdir' instead of 'mkdir -p'... I believe the simple changes that I have made will fix this issue and maybe fix a few other functions as well (i.e. rmdir, rm, and touch). 